### PR TITLE
SVI 2 - missing lambda param

### DIFF
--- a/examples/svi_part_ii.ipynb
+++ b/examples/svi_part_ii.ipynb
@@ -165,6 +165,7 @@
     "    beta = pyro.sample(\"beta\", ...) # sample the global RV\n",
     "    for i in pyro.plate(\"locals\", len(data), subsample_size=5):\n",
     "        # sample the local RVs\n",
+    "        lambda_i = pyro.param(\"lambda_{}\".format(i), ...)\n",
     "        pyro.sample(\"z_{}\".format(i), ..., lambda_i)\n",
     "```\n",
     "\n",


### PR DESCRIPTION
I was a little confused about the explanation of handling global variables in the SVI 2 tutorial. Should lambda_I be defined similar to what's proposed in this PR?